### PR TITLE
Gracefully handle non-responsive IMs and send location data to dependent IMs - Closes #5

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,7 +151,7 @@ def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> d
     connected_apps.discard(service)
     return {}
   if r.status_code >= 400:
-    print('service ' + service.ip + ' returned error code ' + str(r.status_code))
+    print(f'service {service.ip} returned error code {str(r.status_code)}')
     return {}
 
   add_entry_to_cache((lat, lon), service, r)


### PR DESCRIPTION
This PR makes several fixes to MIX:

- MIX will now send lat/long data to IMs which have dependencies:
  - Small fix here. Just added some extra data in the JSON that gets sent to the IMs with this line: `dependency_json.update(latlon_data)`

- Added a "good-enough" solution to handle non-responsive IMs:
  - I implemented the solution using `global` variables as described in my comment on #2. Unfortunately, the time constraints are a little too tight for me to feel confident about implementing an OOP-based solution any time soon. That said, I've tested the current fix locally and MIX is able to handle both singular and multiple IMs being non-responsive and permanently removes them from the running list of IMs. I've also tested caching after the removal and whether or not re-adding a removed IM works, and in both cases MIX seems to function as it should.
  - I've left #2 open for now in light of this being a somewhat incomplete fix. If anyone wants to create an OOP solution to this issue, they're more than free to.

- Moved all IM request code to a single function to avoid redundant code:
  - Not so much a functional adjustment of MIX as it is a code-styling fix. I noticed a lot of redundant code when making to request to an IM, so I migrated all of that code to a single function which makes the request, does error handling, and adjusts the cache and processed list.:
 
```python
def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> dict:
  try:
    r = requests.get(service.ip, json=j)
  except:
    print(f'app at address {service.ip} not connecting. removed from MIX!')
    connected_apps.discard(service)
    return {}
  if r.status_code >= 400:
    print(f'service {service.ip} returned error code {str(r.status_code)}')
    return {}

  add_entry_to_cache((lat, lon), service, r)
  processed[service.ip] = r.json()
  return r.json() 
```

All of these changes has been tested locally and don't require any changes to the IM spec.