### PR TITLE
Dependency management rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,21 @@ In order to add a microservice to MIX, the microservice in question must make a 
     'dependencies' : [
         {
             'port' : 'HOST PORT',
-            'ip' : 'HOST PROTOCOL and IP',
-            'dependencies' : [
-                {
-                    ...and so on. Dependencies can be infinitely nested.
-                }
-            ]
+            'ip' : 'HOST PROTOCOL and IP'
         },
         {
-            'port' : 'HOST,
-            'ip' : 'HOST PROTOCOL and IP',
-            'dependencies' : []
+            'name' : 'Some IM',
+            'creator' : 'Your Name'
         }
     ]
 }
 ```
+
+On the first request, MIX will search the list of connected IMs to match the specified dependencies.
+
+The accepted formats are (in order of match priority):
+- `ip` and `port`
+- `name` and `creator`
 
 To track the IP of the microservice, MIX will fetch the IP from the request.
 
@@ -52,7 +52,9 @@ To remove a microservice from MIX, the microservice must make a `DELETE` request
 
 ## Dependency Handling:
 
-MIX will handle dependencies in a tree-like bottom-up fashion, retrieving the output of all of any IMs dependencies before making a request to that IM. IMs are not required to do dependency handling, as MIX will handle it. All IMs which have dependencies are assumed to not require location data. In order to avoid redundant requests to IMs, MIX maintains a running list of all IMs which have already had requests sent to them.
+MIX will handle dependencies in a tree-like bottom-up fashion, retrieving the output of all of any IMs dependencies before making a request to that IM. IMs are not required to do dependency handling, as MIX will handle it. All IMs which have dependencies are assumed to not require location data.*
+
+*(this is not consistent with MIX behavior, as MIX gives location data to IMs with dependencies.)
 
 ## Requirements for IMs:
 
@@ -74,7 +76,7 @@ MIX will send the following JSON schema to all IMs which do not have any depende
 }
 ```
 
-For IMs with multiple dependencies, MIX will combine the JSON schema of each dependency to send to that IM. Consider the following example:
+For IMs with multiple dependencies, MIX will combine the latitude and longitude with the JSON schema of each dependency to send to that IM. Consider the following example:
 
 IM 1 has dependencies 2 and 3.
 
@@ -98,7 +100,9 @@ IM 1 will receive the following schema as input:
 
 ```
 {
-    'distance' : float
+    'latitude' : float,
+    'longitude' : float,
+    'distance' : float,
     'squared_distance' : float
 }
 ```
@@ -112,3 +116,5 @@ Cache-Control: max-age=x
 ```
 
 where x is some arbitrary number.
+
+Currently, MIX infers the `max-age` of all responses from the first IM response with non-zero `max-age`.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ In order to add a microservice to MIX, the microservice in question must make a 
 
     'dependencies' : [
         {
-            'port' : 'HOST PORT',
-            'ip' : 'HOST PROTOCOL and IP'
+            'name' : 'Another IM',
+            'creator' : 'Your Name'
         },
         {
-            'name' : 'Some IM',
-            'creator' : 'Your Name'
+            'port' : 'HOST PORT',
+            'ip' : 'HOST PROTOCOL and IP'
         }
     ]
 }
@@ -32,8 +32,8 @@ In order to add a microservice to MIX, the microservice in question must make a 
 On the first request, MIX will search the list of connected IMs to match the specified dependencies.
 
 The accepted formats are (in order of match priority):
-- `ip` and `port`
 - `name` and `creator`
+- `ip` and `port`
 
 To track the IP of the microservice, MIX will fetch the IP from the request.
 

--- a/app.py
+++ b/app.py
@@ -60,12 +60,12 @@ def remove_microservice():
 
 
 @app.route('/status', methods=["GET"])
-def list_all_connected_IMs():
+def list_all_connected_services():
     status = [{
         'name': service.name,
         'creator': service.creator,
         'ip': service.ip,
-        'dependencies': [str(depend).split()[-1] for depend in service.dependencies]
+        'dependencies': [depend.ip for depend in service.dependencies]
     } for service in connected_apps]
 
     return jsonify(status), 200
@@ -180,8 +180,14 @@ def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> d
         print(f'service {service.name} at address {service.ip} not connecting. removed from MIX!')
         connected_apps.discard(service)
         return {}
-    if r.status_code >= 400:
-        print(f'service {service.ip} returned error code {str(r.status_code)}')
+
+    if 500 > r.status_code >= 400:
+        print(f'service {service.name} at address {service.ip} returned error code {str(r.status_code)}')
+        return {}
+    elif r.status_code >= 500:
+        print(f'service {service.name} at address {service.ip} returned error code {str(r.status_code)}'
+              f' - removed from MIX!')
+        connected_apps.discard(service)
         return {}
 
     add_entry_to_cache((lat, lon), service, r)

--- a/app.py
+++ b/app.py
@@ -104,14 +104,14 @@ def get_dependencies(dependency_info: [dict]) -> [Microservice]:
         # search for a matching IM
         if 'ip' in dependency and 'port' in dependency:
             for im in connected_apps:
-                if im['ip'] == dependency['ip'] + ':' + dependency['port']:
+                if im.ip == dependency['ip'] + ':' + dependency['port']:
                     dependency_list.append(im)
                     break
             else:
                 raise ValueError('Dependency not found')
         if 'name' in dependency and 'creator' in dependency:
             for im in connected_apps:
-                if im['name'] == dependency['name'] and im['creator'] == dependency['creator']:
+                if im.name == dependency['name'] and im.creator == dependency['creator']:
                     dependency_list.append(im)
                     break
             else:

--- a/app.py
+++ b/app.py
@@ -5,184 +5,192 @@ from microservice import Microservice
 import json
 from datetime import datetime
 
-
 app = Flask(__name__)
 
 connected_apps = set()
 processed = {}
 cache = {}
 
+
 # Route for "/" (frontend):
 @app.route('/')
 def index():
-  return render_template("index.html")
+    return render_template("index.html")
+
 
 @app.route('/microservice', methods=['PUT'])
 def add_microservice():
-  # Verify all required keys are present in JSON:
-  requiredKeys = ['port', 'ip', 'name', 'creator', 'tile']
-  for requiredKey in requiredKeys:
-    if requiredKey not in request.json:
-      return f'Required key {requiredKey} not present in payload JSON.', 400
+    # Verify all required keys are present in JSON:
+    requiredKeys = ['port', 'ip', 'name', 'creator', 'tile']
+    for requiredKey in requiredKeys:
+        if requiredKey not in request.json:
+            return f'Required key {requiredKey} not present in payload JSON.', 400
 
-  # Add the microservice:
-  dependency_list = convert_dependencies_to_objects(request.json['dependencies'])
-  m = Microservice(
-    request.json['ip'] + ':' + request.json['port'],
-    dependency_list,
-    request.json['name'],
-    request.json['creator'],
-    request.json['tile'],
-  )
-  print('connection received from: ' + m.ip)
-  connected_apps.add(m)
+    # Add the microservice:
+    dependency_list = convert_dependencies_to_objects(request.json['dependencies'])
+    m = Microservice(
+        request.json['ip'] + ':' + request.json['port'],
+        dependency_list,
+        request.json['name'],
+        request.json['creator'],
+        request.json['tile'],
+    )
+    print('connection received from: ' + m.ip)
+    connected_apps.add(m)
 
-  return 'Success', 200
+    return 'Success', 200
+
 
 def convert_dependencies_to_objects(dependencies):
-  dp_list = []
-  for x in dependencies:
-    # recursively fetch dependency lists where necessary
-    if list(x['dependencies']) != list():
-      dp_list.append(Microservice(x['ip'] + ':' + x['port'], convert_dependencies_to_objects(x['dependencies'])))
-    else:
-      dp_list.append(Microservice(x['ip'] + ':' + x['port'], []))
-  
-  return dp_list
+    dp_list = []
+    for x in dependencies:
+        # recursively fetch dependency lists where necessary
+        if list(x['dependencies']) != list():
+            dp_list.append(Microservice(x['ip'] + ':' + x['port'], convert_dependencies_to_objects(x['dependencies'])))
+        else:
+            dp_list.append(Microservice(x['ip'] + ':' + x['port'], []))
+
+    return dp_list
 
 
 @app.route('/microservice', methods=['DELETE'])
 def remove_microservice():
-  print('delete request received from: ' + (request.host))
-  previous_len = len(connected_apps)
-  j = request.json
+    print('delete request received from: ' + (request.host))
+    previous_len = len(connected_apps)
+    j = request.json
 
-  if 'ip' not in j or 'port' not in j:
-    return 'Invalid Input', 400
+    if 'ip' not in j or 'port' not in j:
+        return 'Invalid Input', 400
 
-  ip = j['ip'] + ':' + j['port']
-  m = Microservice(ip, [])
+    ip = j['ip'] + ':' + j['port']
+    m = Microservice(ip, [])
 
-  connected_apps.discard(m)
-  if len(connected_apps) == previous_len:
-    return 'Not Found', 404
+    connected_apps.discard(m)
+    if len(connected_apps) == previous_len:
+        return 'Not Found', 404
 
-  return 'Success', 200
+    return 'Success', 200
+
 
 # Route for "/MIX" (middleware):
 @app.route('/MIX', methods=["POST"])
 def POST_MIX():
-  global connected_apps
-  # process form data
-  location = request.form['location']
-  s = location.split(',')
-  lat = float(s[0])
-  lon = float(s[1])
+    global connected_apps
+    # process form data
+    location = request.form['location']
+    s = location.split(',')
+    lat = float(s[0])
+    lon = float(s[1])
 
-  if abs(lat) > 90 or abs(lon) > 90:
-    return 'Invalid input', 400
+    if abs(lat) > 90 or abs(lon) > 90:
+        return 'Invalid input', 400
 
-  # clear list of processed requests from connected apps
-  processed.clear()
+    # clear list of processed requests from connected apps
+    processed.clear()
 
-  # aggregate JSON from all IMs
-  r = []
-  app_list = connected_apps.copy()
-  for app in app_list:
-    # create a response with the metadata about the IM service:
-    j = {
-      '_metadata': {
-        'name': app.name,
-        'creator': app.creator,
-        'tile': app.tile,
-      }
-    }
+    # aggregate JSON from all IMs
+    r = []
+    app_list = connected_apps.copy()
+    for app in app_list:
+        # create a response with the metadata about the IM service:
+        j = {
+            '_metadata': {
+                'name': app.name,
+                'creator': app.creator,
+                'tile': app.tile,
+            }
+        }
 
-    # add the IM response:
-    if cache_hit((lat, lon), app):
-      j.update( cache[(lat, lon)][app.ip][0] )
-    else:
-      j.update( process_request(app, lat, lon) )
+        # add the IM response:
+        if cache_hit((lat, lon), app):
+            j.update(cache[(lat, lon)][app.ip][0])
+        else:
+            j.update(process_request(app, lat, lon))
 
-    r.append(j)
+        r.append(j)
 
-  return jsonify(r), 200
+    return jsonify(r), 200
+
 
 def process_request(service: Microservice, lat: float, lon: float) -> dict:
-  latlon_data = {'latitude': lat, 'longitude': lon}
-  # if we've already processed an IM, we're finished
-  if service.ip in processed:
-    return processed[service.ip]
+    latlon_data = {'latitude': lat, 'longitude': lon}
+    # if we've already processed an IM, we're finished
+    if service.ip in processed:
+        return processed[service.ip]
 
-  if len(service.dependencies) == 0:
-    # send a request to each service
-    return make_im_request(service, latlon_data, lat, lon)
-  else:
-    # aggregate all dependency data and send as a request to our IM
-    dependency_json = get_dependency_data(service, lat, lon)
-    dependency_json.update(latlon_data)
-    return make_im_request(service, dependency_json, lat, lon)
-
-
-def get_dependency_data(service: Microservice, lat: float, lon: float) -> dict:  
-  j = {}
-  for dependency in service.dependencies:
-    # handle dependencies which have their own dependencies recursively
-    if len(dependency.dependencies) > 0:
-      for dd in dependency.dependencies:
-        j.update(get_dependency_data(dd, lat, lon))
-
+    if len(service.dependencies) == 0:
+        # send a request to each service
+        return make_im_request(service, latlon_data, lat, lon)
     else:
-      # if we've already made a request to this IM, just fetch from our processed requests dict
-      if dependency.ip in processed:
-        j.update(processed[dependency.ip])
-      else:
-        # make new request to IM
-        latlon_data = {'latitude' : lat, 'longitude' : lon}
-        j.update(make_im_request(dependency, latlon_data, lat, lon))       
+        # aggregate all dependency data and send as a request to our IM
+        dependency_json = get_dependency_data(service, lat, lon)
+        dependency_json.update(latlon_data)
+        return make_im_request(service, dependency_json, lat, lon)
 
-  return j
+
+def get_dependency_data(service: Microservice, lat: float, lon: float) -> dict:
+    j = {}
+    for dependency in service.dependencies:
+        # handle dependencies which have their own dependencies recursively
+        if len(dependency.dependencies) > 0:
+            for dd in dependency.dependencies:
+                j.update(get_dependency_data(dd, lat, lon))
+
+        else:
+            # if we've already made a request to this IM, just fetch from our processed requests dict
+            if dependency.ip in processed:
+                j.update(processed[dependency.ip])
+            else:
+                # make new request to IM
+                latlon_data = {'latitude': lat, 'longitude': lon}
+                j.update(make_im_request(dependency, latlon_data, lat, lon))
+
+    return j
+
 
 def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> dict:
-  try:
-    r = requests.get(service.ip, json=j)
-  except:
-    print(f'app at address {service.ip} not connecting. removed from MIX!')
-    connected_apps.discard(service)
-    return {}
-  if r.status_code >= 400:
-    print(f'service {service.ip} returned error code {str(r.status_code)}')
-    return {}
+    try:
+        r = requests.get(service.ip, json=j)
+    except:
+        print(f'app at address {service.ip} not connecting. removed from MIX!')
+        connected_apps.discard(service)
+        return {}
+    if r.status_code >= 400:
+        print(f'service {service.ip} returned error code {str(r.status_code)}')
+        return {}
 
-  add_entry_to_cache((lat, lon), service, r)
-  processed[service.ip] = r.json()
-  return r.json()
+    add_entry_to_cache((lat, lon), service, r)
+    processed[service.ip] = r.json()
+    return r.json()
+
 
 def parse_cache_header(header: str) -> int:
-  return float(header.split('=')[1])
+    return float(header.split('=')[1])
+
 
 def add_entry_to_cache(latlon: tuple, service: Microservice, response) -> None:
-  # set max_age for a service if it has not been set already
-  if service.max_age == 0:
-    service.max_age = parse_cache_header(response.headers['Cache-Control'])
-  
-  # enter the service response json into our cache
-  if latlon not in cache:
-    cache[latlon] = {service.ip : (response.json(), datetime.now())}
-  else:
-    cache[latlon][service.ip] = (response.json(), datetime.now())
+    # set max_age for a service if it has not been set already
+    if service.max_age == 0:
+        service.max_age = parse_cache_header(response.headers['Cache-Control'])
+
+    # enter the service response json into our cache
+    if latlon not in cache:
+        cache[latlon] = {service.ip: (response.json(), datetime.now())}
+    else:
+        cache[latlon][service.ip] = (response.json(), datetime.now())
+
 
 def cache_hit(latlong: tuple, service: Microservice) -> bool:
-  if service.max_age == 0 or latlong not in cache or service.ip not in cache.get(latlong):
-    print('cache miss! entry not in cache')
+    if service.max_age == 0 or latlong not in cache or service.ip not in cache.get(latlong):
+        print('cache miss! entry not in cache')
+        return False
+
+    curr_time = datetime.now()
+    timediff = curr_time - cache[latlong][service.ip][1]
+
+    if timediff.total_seconds() < service.max_age:
+        print('cache hit!')
+        return True
+
+    print('cache miss! exceeded max_age')
     return False
-  
-  curr_time = datetime.now()
-  timediff = curr_time - cache[latlong][service.ip][1]
-
-  if timediff.total_seconds() < service.max_age:
-    print('cache hit!')
-    return True
-
-  print('cache miss! exceeded max_age')
-  return False

--- a/app.py
+++ b/app.py
@@ -21,10 +21,10 @@ def index():
 @app.route('/microservice', methods=['PUT'])
 def add_microservice():
     # Verify all required keys are present in JSON:
-    requiredKeys = ['port', 'ip', 'name', 'creator', 'tile']
-    for requiredKey in requiredKeys:
-        if requiredKey not in request.json:
-            return f'Required key {requiredKey} not present in payload JSON.', 400
+    required_keys = ['port', 'ip', 'name', 'creator', 'tile']
+    for required_key in required_keys:
+        if required_key not in request.json:
+            return f'Required key {required_key} not present in payload JSON.', 400
 
     # Add the microservice:
     dependency_list = convert_dependencies_to_objects(request.json['dependencies'])
@@ -55,7 +55,7 @@ def convert_dependencies_to_objects(dependencies):
 
 @app.route('/microservice', methods=['DELETE'])
 def remove_microservice():
-    print('delete request received from: ' + (request.host))
+    print(f'delete request received from: {request.host}')
     previous_len = len(connected_apps)
     j = request.json
 
@@ -151,8 +151,8 @@ def get_dependency_data(service: Microservice, lat: float, lon: float) -> dict:
 def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> dict:
     try:
         r = requests.get(service.ip, json=j)
-    except:
-        print(f'app at address {service.ip} not connecting. removed from MIX!')
+    except requests.exceptions.RequestException:
+        print(f'app {service.name} at address {service.ip} not connecting. removed from MIX!')
         connected_apps.discard(service)
         return {}
     if r.status_code >= 400:
@@ -164,7 +164,7 @@ def make_im_request(service: Microservice, j: dict, lat: float, lon: float) -> d
     return r.json()
 
 
-def parse_cache_header(header: str) -> int:
+def parse_cache_header(header: str) -> float:
     return float(header.split('=')[1])
 
 

--- a/app.py
+++ b/app.py
@@ -102,16 +102,16 @@ def get_dependencies(dependency_info: [dict]) -> [Microservice]:
     dependency_list = []
     for dependency in dependency_info:
         # search for a matching IM
-        if 'ip' in dependency and 'port' in dependency:
+        if 'name' in dependency and 'creator' in dependency:
             for im in connected_apps:
-                if im.ip == dependency['ip'] + ':' + dependency['port']:
+                if im.name == dependency['name'] and im.creator == dependency['creator']:
                     dependency_list.append(im)
                     break
             else:
                 raise ValueError('Dependency not found')
-        if 'name' in dependency and 'creator' in dependency:
+        elif 'ip' in dependency and 'port' in dependency:
             for im in connected_apps:
-                if im.name == dependency['name'] and im.creator == dependency['creator']:
+                if im.ip == dependency['ip'] + ':' + dependency['port']:
                     dependency_list.append(im)
                     break
             else:

--- a/microservice.py
+++ b/microservice.py
@@ -21,4 +21,4 @@ class Microservice:
         return self.ip == other.ip
 
     def __ne__(self, other) -> bool:
-        return (not self.__eq__(other))
+        return not self.__eq__(other)

--- a/microservice.py
+++ b/microservice.py
@@ -1,25 +1,24 @@
 class Microservice:
-  ip = None
-  dependencies = []
-  max_age = None
-  name = None
-  creator = None
-  tile = None
+    ip = None
+    dependencies = []
+    max_age = None
+    name = None
+    creator = None
+    tile = None
 
-  def __init__(self, host, d, name = None, creator = None, tile = None):
-    self.ip = host
-    self.dependencies = d
-    self.max_age = 0
-    self.name = name
-    self.creator = creator
-    self.tile = tile
+    def __init__(self, host, d, name=None, creator=None, tile=None):
+        self.ip = host
+        self.dependencies = d
+        self.max_age = 0
+        self.name = name
+        self.creator = creator
+        self.tile = tile
 
-  def __hash__(self) -> int:
-    return hash(self.ip)
-  
-  def __eq__(self, other) -> bool:
-    return self.ip == other.ip
+    def __hash__(self) -> int:
+        return hash(self.ip)
 
-  def __ne__(self, other) -> bool:
-    return (not self.__eq__(other))
-    
+    def __eq__(self, other) -> bool:
+        return self.ip == other.ip
+
+    def __ne__(self, other) -> bool:
+        return (not self.__eq__(other))

--- a/microservice.py
+++ b/microservice.py
@@ -1,6 +1,7 @@
 class Microservice:
     ip = None
-    dependencies = []
+    dependency_info = []
+    dependencies = None
     max_age = None
     name = None
     creator = None
@@ -8,7 +9,7 @@ class Microservice:
 
     def __init__(self, host, d, name=None, creator=None, tile=None):
         self.ip = host
-        self.dependencies = d
+        self.dependency_info = d
         self.max_age = 0
         self.name = name
         self.creator = creator

--- a/microservice.py
+++ b/microservice.py
@@ -23,6 +23,3 @@ class Microservice:
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
-
-    def __repr__(self) -> str:
-        return f"{self.tile} {self.name} IM by {self.creator} at {self.ip}"


### PR DESCRIPTION
Resolves #3 and #6
- Removed redundant `processed` dictionary and replaced usage with `cache`.
- Removed `convert_dependencies_to_objects()`. (was broken, now unnecessary under the new dependency management.)
- Added `get_dependencies()` to search dependencies on first runtime.
  - this resolves #3 
  - dependencies can currently be specified by [ip and port], or by [name and creator].
- Removed the redundant recursive function `get_dependency_data()` and made `process_request()` recursive.
  - `process_request()` will check for circular dependencies by keeping track of dependency lineage (via `visited`).
  - this resolves #6 
- Moved cache check from `POST_MIX()` to `process_request()` to run recursively for dependencies.
- Added docstrings

The previous dependency manager had some questionable behavior (e.g. include responses from indirect dependencies in the request). Behavior also did not align with the documentation (latitude and longitude are given to IMs with dependencies).


See: 
https://github.com/cs240-illinois/cs240-fa21-MIX_shared/pull/20/files/ba9bdf7796fac34d1081b7d96f477ae4248e9972..db2681720a05814d310a411708260e32e450cd57 
git diff is a bit messed up.