### PR TITLE
fix `/status`, improve cache-control robustness, update documentation, add type checking for registration, no more `|=` for dict update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,33 @@
 
 In order to add a microservice to MIX, the microservice in question must make a `PUT` request to the /microservice endpoint. The `PUT` request must send JSON adhering to the following schema:
 
-```
+```json
 {
-    'port' : 'HOST PORT',
-    'ip' : 'HOST PROTOCOL and IP',
+    "port" : "HOST PORT",
+    "ip" : "HOST PROTOCOL and IP",
 
-    'name': 'Sunrise Time',
-    'creator': 'Your Name',
-    'tile': 'For use on the front-end display (ex: Sunrise Time ☀️)',
+    "name": "Sunrise Time",
+    "creator": "Your Name",
+    "tile": "For use on the front-end display (ex: Sunrise Time ☀️)",
 
-    'dependencies' : [
+    "dependencies" : [
         {
-            'name' : 'Another IM',
-            'creator' : 'Your Name'
+            "name" : "Some IM",
+            "creator" : "Your Name"
         },
         {
-            'port' : 'HOST PORT',
-            'ip' : 'HOST PROTOCOL and IP'
+            "name" : "Another IM",
+            "creator" : "Your Name"
+        },
+        {
+            "port" : "IM port",
+            "ip" : "IM host protocol and IP"
         }
     ]
 }
 ```
 
-On the first request, MIX will search the list of connected IMs to match the specified dependencies.
+On the first request to the IM, MIX will search the list of connected IMs to match the specified dependencies.
 
 The accepted formats are (in order of match priority):
 - `name` and `creator`
@@ -43,10 +47,10 @@ To handle multiple IMs, MIX maintains a running list of all connected IMs. MIX w
 
 To remove a microservice from MIX, the microservice must make a `DELETE` request to the /microservice endpoint. The `DELETE` request must send JSON adhering to the following schema:
 
-```
+```json
 { 
-    'port' : 'HOST PORT'
-    'ip' : 'HOST IP'
+    "port" : "HOST PORT",
+    "ip" : "HOST IP"
 }
 ```
 
@@ -54,7 +58,7 @@ To remove a microservice from MIX, the microservice must make a `DELETE` request
 
 MIX will handle dependencies in a tree-like bottom-up fashion, retrieving the output of all of any IMs dependencies before making a request to that IM. IMs are not required to do dependency handling, as MIX will handle it. All IMs which have dependencies are assumed to not require location data.*
 
-*(this is not consistent with MIX behavior, as MIX gives location data to IMs with dependencies.)
+*This is not actually consistent with MIX behavior, as MIX gives location data to IMs with dependencies.
 
 ## Requirements for IMs:
 
@@ -69,10 +73,10 @@ MIX will handle dependencies in a tree-like bottom-up fashion, retrieving the ou
 
 MIX will send the following JSON schema to all IMs which do not have any dependencies:
 
-```
+```json
 {
-    'latitude' : float,
-    'longitude' : float
+    "latitude" : float,
+    "longitude" : float
 }
 ```
 
@@ -82,28 +86,28 @@ IM 1 has dependencies 2 and 3.
 
 IM 2 has the following schema:
 
-```
+```json
 {
-    'distance' : float
+    "distance" : float
 }
 ```
 
 IM 3 has the following schema:
 
-```
+```json
 {
-    'squared_distance' : float
+    "squared_distance" : float
 }
 ```
 
 IM 1 will receive the following schema as input:
 
-```
+```json
 {
-    'latitude' : float,
-    'longitude' : float,
-    'distance' : float,
-    'squared_distance' : float
+    "latitude" : float,
+    "longitude" : float,
+    "distance" : float,
+    "squared_distance" : float
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ MIX will send the following JSON schema to all IMs which do not have any depende
 
 ```json
 {
-    "latitude" : float,
-    "longitude" : float
+    "latitude" : 11.1234,
+    "longitude" : 22.1234
 }
 ```
 
@@ -88,7 +88,7 @@ IM 2 has the following schema:
 
 ```json
 {
-    "distance" : float
+    "distance" : 5
 }
 ```
 
@@ -96,7 +96,7 @@ IM 3 has the following schema:
 
 ```json
 {
-    "squared_distance" : float
+    "squared_distance" : 25
 }
 ```
 
@@ -104,10 +104,10 @@ IM 1 will receive the following schema as input:
 
 ```json
 {
-    "latitude" : float,
-    "longitude" : float,
-    "distance" : float,
-    "squared_distance" : float
+    "latitude" : 11.1234,
+    "longitude" : 22.1234,
+    "distance" : 5,
+    "squared_distance" : 25
 }
 ```
 

--- a/app.py
+++ b/app.py
@@ -101,14 +101,14 @@ def POST_MIX():
         j = process_request(im, lat, lon)
 
         # add metadata about the IM service:
-        j |= {
+        j.update({
             '_metadata': {
                 'name': im.name,
                 'creator': im.creator,
                 'tile': im.tile,
                 'max-age': im.max_age
             }
-        }
+        })
 
         r.append(j)
 
@@ -169,7 +169,7 @@ def process_request(service: Microservice, lat: float, lon: float, visited=tuple
             return {}
         else:
             # concatenate results to dependency_results
-            dependency_results |= process_request(dependency, lat, lon, visited + (dependency,))
+            dependency_results.update(process_request(dependency, lat, lon, visited + (dependency,)))
 
     return make_im_request(service, dependency_results, lat, lon)
 

--- a/app.py
+++ b/app.py
@@ -26,12 +26,8 @@ def add_microservice():
         if required_key not in request.json:
             return f'Required key {required_key} not present in payload JSON.', 400
 
-        if required_key != 'port':
-            if type(request.json) != str:
-                return f'Required key {required_key} has invalid type in payload JSON (should be str).', 400
-        else:
-            if type(request.json) not in [str, int]:
-                return f'Required key {required_key} has invalid type in payload JSON (should be str or int).', 400
+        if isinstance(request.json, str):
+            return f'Required key {required_key} has invalid type in payload JSON (should be str).', 400
 
     # Add the microservice:
     m = Microservice(

--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ def list_all_connected_services():
         'name': service.name,
         'creator': service.creator,
         'ip': service.ip,
-        'dependencies': [depend.ip for depend in service.dependencies]
+        'dependencies': [depend.ip for depend in service.dependencies] if service.dependencies is not None else []
     } for service in connected_apps]
 
     return jsonify(status), 200

--- a/app.py
+++ b/app.py
@@ -26,6 +26,13 @@ def add_microservice():
         if required_key not in request.json:
             return f'Required key {required_key} not present in payload JSON.', 400
 
+        if required_key != 'port':
+            if type(request.json) != str:
+                return f'Required key {required_key} has invalid type in payload JSON (should be str).', 400
+        else:
+            if type(request.json) not in [str, int]:
+                return f'Required key {required_key} has invalid type in payload JSON (should be str or int).', 400
+
     # Add the microservice:
     m = Microservice(
         request.json['ip'] + ':' + request.json['port'],

--- a/microservice.py
+++ b/microservice.py
@@ -1,16 +1,16 @@
 class Microservice:
     ip = None
     dependency_info = []
-    dependencies = None
-    max_age = None
     name = None
     creator = None
     tile = None
 
+    dependencies = None
+    max_age = None
+
     def __init__(self, host, d, name=None, creator=None, tile=None):
         self.ip = host
         self.dependency_info = d
-        self.max_age = 0
         self.name = name
         self.creator = creator
         self.tile = tile


### PR DESCRIPTION
- fixed `/status` for IMs with no dependencies (caused 500 errors before)
- added support for IMs with no Cache-Control
  - fixes #21
- made parse_cache_header more robust (automatic fallback to no-cache for invalid Cache-Control)
- added type checking for required json keys
- changed `|=` to `dict.update()` for backwards compatibility from python 3.9