### PR TITLE
Catch all errors raised during `process_request`

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,13 @@ def POST_MIX():
     r = []
     for im in connected_apps.copy():
         # get the IM response:
-        j = process_request(im, lat, lon)
+        try:
+            j = process_request(im, lat, lon)
+        except Exception as e:
+            print(im)
+            print(e)
+            connected_apps.discard(im)
+            continue
 
         # add metadata about the IM service:
         j.update({

--- a/microservice.py
+++ b/microservice.py
@@ -23,3 +23,6 @@ class Microservice:
 
     def __ne__(self, other) -> bool:
         return not self.__eq__(other)
+
+    def __str__(self) -> str:
+        return f'Microservice(ip={self.ip},  name={self.name}, creator={self.creator})'


### PR DESCRIPTION
When an exception is thrown in `process_request`, the error is caught in the `POST_MIX` route, the error is logged to console, and then IM removed.  This fixes #28 and any related errors if an IM causes unexpected behavior.